### PR TITLE
fix: Remove unnecessary global fetch in ApiConfig class

### DIFF
--- a/src/lib/js/classes.js
+++ b/src/lib/js/classes.js
@@ -1,4 +1,3 @@
-/* global fetch */
 import { APIKEY, APISTRING } from "$lib/js/constants.js"
 
 export class ApiConfig {


### PR DESCRIPTION
Do not need to declare global fetch because of built-in fetch from load.
REF: https://scottspence.com/posts/sveltekit-data-loading-understanding-the-load-function