### PR TITLE
fix: update deploy script to use 'build' directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
-    "deploy": "vite build && git add dist && git commit -m 'Deploy to GitHub Pages' && git push origin `git subtree split --prefix dist main`:gh-pages --force"
+    "deploy": "vite build && git add dist && git commit -m 'Deploy to GitHub Pages' && git push origin `git subtree split --prefix build main`:gh-pages --force"
   },
   "devDependencies": {
     "@playwright/test": "^1.28.1",


### PR DESCRIPTION
Update the deploy script in package.json to reference the 'build'  directory instead of 'dist'. This change ensures that the correct  output folder is used for deployment to GitHub Pages.