### PR TITLE
fix: update deployment paths to use 'dist'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
-    "deploy": "vite build && git add dist && git commit -m 'Deploy to GitHub Pages' && git push origin `git subtree split --prefix build main`:gh-pages --force"
+    "deploy": "vite build && git add dist && git commit -m 'Deploy to GitHub Pages' && git push origin `git subtree split --prefix dist main`:gh-pages --force"
   },
   "devDependencies": {
     "@playwright/test": "^1.28.1",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,8 +12,8 @@ const config = {
 		adapter: adapter({
 			// default options are shown. On some platforms
 			// these options are set automatically — see below
-			pages: 'build',
-			assets: 'build',
+			pages: 'dist',
+			assets: 'dist',
 			fallback: undefined,
 			precompress: false,
 			strict: true


### PR DESCRIPTION
Change the deployment script in package.json and the adapter 
configuration in svelte.config.js to use the 'dist' directory 
instead of 'build'. This ensures that the correct output folder 
is referenced for deployment to GitHub Pages.