### PR TITLE
chore: remove build directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules
 .output
 .vercel
 /.svelte-kit
-/build
 
 # OS
 .DS_Store


### PR DESCRIPTION
Removes the build directory from the .gitignore file to allow 
tracking of build artifacts. This change facilitates better 
collaboration and ensures that necessary build files are 
included in version control.