### PR TITLE
refactor: simplify Graph component usage and clean imports

### DIFF
--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { getContext } from 'svelte';
     export let name: string;
     export let id: string;
     export let data: {index: string, id: string}[];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
     </section>
     <section class="form">
         <Form --bg-color="#f5f5f5" />
-        <Graph --bg-color="#f5f5f5" />
+        <Graph />
     </section>
 </main>
 


### PR DESCRIPTION
Removes the background color prop from the Graph component to  streamline its usage. Cleans up the Select component by removing  an unnecessary import of getContext, improving code clarity  and maintainability.